### PR TITLE
tempo-service: change datetime parsing to ISO 8601

### DIFF
--- a/service/tempo-core/src/main/java/com/tempo/service/core/services/AssignmentService.java
+++ b/service/tempo-core/src/main/java/com/tempo/service/core/services/AssignmentService.java
@@ -51,7 +51,7 @@ public class AssignmentService extends HttpServlet {
             var map = check(request, response, "userEmail", "room", "dateFrom", "endTime");
             if (map == null) return;
 
-            var dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            var dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
             var timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
             var rows = db.execute(sql -> sql.insertInto(ASSIGNMENT)
                     .set(ASSIGNMENT.USER_EMAIL, map.get("userEmail"))

--- a/service/tempo-core/src/main/java/com/tempo/service/core/services/MeetingService.java
+++ b/service/tempo-core/src/main/java/com/tempo/service/core/services/MeetingService.java
@@ -43,7 +43,7 @@ public class MeetingService extends HttpServlet {
                     "endTime", "organiser");
             if (map == null) return;
 
-            var dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            var dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
             var timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
             var rows = db.execute(sql -> sql.insertInto(MEETING)
                     .set(MEETING.QR_HASH, map.get("qrHash"))


### PR DESCRIPTION
The client code tries to send datetime values in ISO 8601 format, but
the current service only accepts `yyyy-MM-dd HH:mm:ss`.

Change any occurences of `yyyy-MM-dd HH:mm:ss` into ISO 8601
(`yyyy-MM-dd'T'HH:mm:ss.SSS'`).